### PR TITLE
Ensure this plugin doesn't break sourcemaps for the rest of the app.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function compileSvg(source, filename, ssr) {
     hydratable: true,
     css: false,
   });
-  return { code };
+  return { code, map: { mappings: '' } };
 }
 
 function optimizeSvg(content, path, config = {}) {


### PR DESCRIPTION
Sourcemaps still don't work for the transformed components, but at least it doesn't
spoils the sourcemaps for the rest of the bundle.