### PR TITLE
 style(index.js): add namespace option to svelte compiler options

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function compileSvg(source, filename, ssr) {
     dev: process.env.NODE_ENV === "development",
     hydratable: true,
     css: false,
+    namespace: "svg",
   });
   return { code, map };
 }


### PR DESCRIPTION
The namespace option is added to the svelte compiler options to allow the generated code to be namespaced. This is useful when integrating Svelte components into an existing codebase to avoid naming conflicts.